### PR TITLE
Resolve bug unclickable Zoom in and Zoom out (muk_web_theme)

### DIFF
--- a/dhx_gantt/static/src/css/gantt.css
+++ b/dhx_gantt/static/src/css/gantt.css
@@ -13,6 +13,7 @@
 
 .o_dhx_gantt_header{
     background-color: white;
+    min-height: 40px;
    /* position: relative;
     display: -webkit-box;
     display: -webkit-flex;


### PR DESCRIPTION
Resolve bug unclickable Zoom in and Zoom out on Macbook Pro 2021 Resolution Screen, Chrome Browser, "MuK Backend Theme " muk_web_theme as theme.
Without this, the Zoom in and Zoom out button is unclickable. I'm using muk_web_theme when try this.